### PR TITLE
Add switch for docker to remove containers after use

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ This docker image provides an environment to update the firmware from the shippe
 **Please note** that as of September 2020, the 6.x releases and higher will require Home Assistant 0.115 or higher. 
 
 ## To use:
-`docker run --device=/dev/ttyUSB1:/dev/ttyUSB1 -it walthowd/husbzb-firmware`
+`docker run --rm --device=/dev/ttyUSB1:/dev/ttyUSB1 -it walthowd/husbzb-firmware`
 
 Replace */dev/ttyUSB1* with the path to the zigbee side of your USB stick. Make sure that nothing else is currently using the port (i.e. Shutdown and stop Home Assistant)
 
 Example output, currently just a scan reporting current FW version: 
 ```
-docker run --device=/dev/ttyUSB1:/dev/ttyUSB1 -it walthowd/husbzb-firmware
+docker run --rm --device=/dev/ttyUSB1:/dev/ttyUSB1 -it walthowd/husbzb-firmware
 {"ports": [{"stackVersion": "5.4.1-194", "deviceType": "zigbee", "pid": "8A2A", "port": "/dev/ttyUSB1", "vid": "10C4"}]}
 Found zigbee port at /dev/ttyUSB1 running 5.4.1-194
 ```
@@ -25,7 +25,7 @@ If you want to use this image to manually update your firmware first shut down H
 Then start a shell from the docker image:
 
 ```
-docker run --device=/dev/ttyUSB1:/dev/ttyUSB1 -it walthowd/husbzb-firmware bash
+docker run --rm --device=/dev/ttyUSB1:/dev/ttyUSB1 -it walthowd/husbzb-firmware bash
 ```
 Make sure you are in */tmp/silabs* by changing directory and then flash:
 ```
@@ -57,7 +57,7 @@ NOTE: This is currently in testing mode.
 
 To backup your existing configration:
 ```
-docker run --device=/dev/ttyUSB1:/dev/ttyUSB1 -v .:/data -e EZSP_DEVICE='/dev/ttyUSB1' -e LANG='C.UTF-8' -it walthowd/husbzb-firmware bash
+docker run --rm --device=/dev/ttyUSB1:/dev/ttyUSB1 -v .:/data -e EZSP_DEVICE='/dev/ttyUSB1' -e LANG='C.UTF-8' -it walthowd/husbzb-firmware bash
 bellows info
 bellows backup > /data/bellows-backup.txt
 exit
@@ -65,7 +65,7 @@ exit
 
 Remove old stick, insert new stick (find correct ttyUSB port in `dmesg`) and restart container:
 ```
-docker run --device=/dev/ttyUSB1:/dev/ttyUSB1 -v .:/data -e EZSP_DEVICE='/dev/ttyUSB1' -e LANG='C.UTF-8' -it walthowd/husbzb-firmware bash
+docker run --rm --device=/dev/ttyUSB1:/dev/ttyUSB1 -v .:/data -e EZSP_DEVICE='/dev/ttyUSB1' -e LANG='C.UTF-8' -it walthowd/husbzb-firmware bash
 bellows info
 bellows restore --i-understand-i-can-update-eui64-only-once-and-i-still-want-to-do-it -B /data/bellows-backup.txt
 bellows info


### PR DESCRIPTION
There is no need for these containers after they've run, so we can let docker remove them.