### PR TITLE
Add support for Sonoff ZBDongle-E stick

### DIFF
--- a/ncp.py
+++ b/ncp.py
@@ -52,7 +52,7 @@ WSTK_RTS_CTS = True
 
 # ITEAD/SONOFF EFR32 USB Stick
 SONOFF_VID = '1A86'
-SONOFF_PID = '7523'
+SONOFF_PIDS = ['7523', '55D4']
 SONOFF_BAUD = 115200
 SONOFF_XON_XOFF = True
 SONOFF_RTS_CTS = False
@@ -266,7 +266,7 @@ def flash(port, file):
                 RTS_CTS = ETRX_RTS_CTS
                 break
             # Check if SONOFF  stick
-            if vid == SONOFF_VID and pid == SONOFF_PID:
+            if vid == SONOFF_VID and pid in SONOFF_PIDS:
                 print('SONOFF stick')
                 BAUD = SONOFF_BAUD
                 XON_XOFF = SONOFF_XON_XOFF
@@ -391,7 +391,7 @@ def scan():
             portjson['pid'] = pid
 
             # Check which USB NCP device
-            if vid == CEL_VID and pid == CEL_PID or vid == WSTK_VID and pid == WSTK_PID or vid == ETRX_VID and pid == ETRX_PID or vid == SONOFF_VID and pid == SONOFF_PID:
+            if vid == CEL_VID and pid == CEL_PID or vid == WSTK_VID and pid == WSTK_PID or vid == ETRX_VID and pid == ETRX_PID or vid == SONOFF_VID and pid in SONOFF_PIDS:
                 # Use EM3588 USB stick as default
                 BAUD = CEL_BAUD
                 XON_XOFF = CEL_XON_XOFF
@@ -402,7 +402,7 @@ def scan():
                     XON_XOFF = WSTK_XON_XOFF
                     RTS_CTS = WSTK_RTS_CTS
                 # Check if SONOFF board
-                if vid == SONOFF_VID and pid == SONOFF_PID:
+                if vid == SONOFF_VID and pid in SONOFF_PIDS:
                     BAUD = SONOFF_BAUD
                     XON_XOFF = SONOFF_XON_XOFF
                     RTS_CTS = SONOFF_RTS_CTS


### PR DESCRIPTION
The Sonoff ZBDongle-E uses a CH9102F UART chip which has a new pid ```55D4```, but otherwise is very similar to the original Sonoff EFR32 stick. See Issue: #44

This patch adds support for the new pid.

I have tested using the [Itead provided firmware](https://github.com/itead/Sonoff_Zigbee_Dongle_Firmware/tree/master/Dongle-E)