### PR TITLE
timeout error fix bellows install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /tmp/silabs
 RUN apt-get update \
   && apt-get install -y git wget python3-pip unzip jq curl
 
-RUN pip3 install --upgrade git+git://github.com/zigpy/bellows.git
+RUN pip3 install --upgrade git+https://github.com/zigpy/bellows.git
 
 RUN pip3 install pyserial xmodem
 

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -10,7 +10,7 @@ RUN apt-get update \
 
 RUN pip install xmodem pyserial
 
-RUN pip3 install --upgrade git+git://github.com/zigpy/bellows.git
+RUN pip3 install --upgrade git+https://github.com/zigpy/bellows.git
 
 RUN mkdir -p /tmp/silabs
 


### PR DESCRIPTION
The Dockerfiles try to install bellows.git via pip3 from GitHub link directly. The command fixed from `RUN pip3 install --upgrade git+git://github.com/zigpy/bellows.git` to 'RUN pip3 install --upgrade git+https://github.com/zigpy/bellows.git'

With this proper call the bellows.git can be installed into pip3, ncp.py run on macOS succesfully (On Linux x86_64 only scan works though, rPI not tested).